### PR TITLE
Updated vagrantfile and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@ configuring you're metasploit development environment.
 # Requirements
 ## Platform
 The following systems are supported ***and*** tested on:
-* Mac OS X Mountain Lion and above (10.8+) w/ XCode Developer tools.
+* Mac OS X Mountain Lion and above (10.8+) + Command Line Tools.
 * Ubuntu Precise Pangolin and above(12.04+)
 
 A rule of thumb is that if you're running a flavor of linux/unix your system is
 already supported. If you're running Windows, feel free to tweak some recipes to
 add support by editing the case-when `node[:platform]` blocks and adding
 `when 'windows'`.
+
+
+### Installong the Command Line Tools for OS X
+
+Xcode is a nearly 4GB developer suite Apple offers for free from the Mac App Store. However, for the purposes of getting Berkshelf installed you’ll only need a specific set of command line tools which fortunately take up much less space.  If you don’t mind the 4GB, by all means go for Xcodem from the app store. Otherwise, you’ll have go to connect.apple.com and register an Apple Developer account. Once you’ve registered you can find them at developer.apple.com/xcode by clicking on “View downloads” and finding the appropriate command line tools for your version of OS X.
 
 ## Vagrant
 * Vagrant 1.2+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ configuring you're metasploit development environment.
 # Requirements
 ## Platform
 The following systems are supported ***and*** tested on:
-* Mac OS X Mountain Lion and above (10.8+)
+* Mac OS X Mountain Lion and above (10.8+) w/ XCode Developer tools.
 * Ubuntu Precise Pangolin and above(12.04+)
 
 A rule of thumb is that if you're running a flavor of linux/unix your system is
@@ -13,9 +13,20 @@ already supported. If you're running Windows, feel free to tweak some recipes to
 add support by editing the case-when `node[:platform]` blocks and adding
 `when 'windows'`.
 
+## Vagrant
+* Vagrant 1.2+
+* Vagrant Berkshelf 1.3.2+
+* Vagrant Omnibus  1.1.0+
+
+
 # Usage
-Just include `recipe[metasploit::default]` in your node's run list. If
-you'd like to create a machine with vagrant ensure you've run the
+
+## Chef
+Just include `recipe[metasploit::default]` in your node's run list.
+
+## Vagrant
+
+To create a machine with vagrant ensure you've run the
 following commands after installing vagrant from vagrantup.com:
 
 ```
@@ -24,6 +35,12 @@ vagrant plugin list
 # If vagrant-berkshelf (1.3.2+) and vagrant-omnibus (1.1.0) aren't installed:
 vagrant plugin install vagrant-berkshelf
 vagrant plugin install vagrant-omnibus
+```
+
+Once you have the necessary plugins you simply want to run
+
+```
+vagrant up
 ```
 
 # Attributes

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,6 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'precise64'
   config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
   config.vm.network :private_network, ip: '33.33.33.10'
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
 
   config.vm.provision :chef_solo do |chef|
     chef.run_list = %w[recipe[metasploit::default]]


### PR DESCRIPTION
I updated the readme to hopefully help new users, which may not understand the relationship of Vagrant and Chef.  I also removed max_retried and timeout since those appear to be deprecated attributes in Vagrant 1.3.5, and their presence caused vagrant up to fail

``` shell
jdyer@retina:~/Projects/metasploit(master○) » vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

SSH:
* The following settings shouldn't exist: max_tries, timeout


```
